### PR TITLE
support globs + a little security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This extension allows you to validate email domain used for registration in keycloak to accept only a finite list of domain.
 
+You can use basic [glob syntax](https://en.wikipedia.org/wiki/Glob_(programming))
+(only `*` and `?` are supported)
+
 ## How to install
 
 Simply drop the jar in `$KEYCLOAK_HOME\standalone\deployments`, it will be automatically deployed by keycloak.

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
@@ -55,6 +55,38 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
       CONFIG_PROPERTIES.add(property);
    }
 
+   private static final boolean globmatches(String text, String glob) {
+      if (text.length() > 200) {
+         return false;
+      }
+      String rest = null;
+      int pos = glob.indexOf('*');
+      if (pos != -1) {
+         rest = glob.substring(pos + 1);
+         glob = glob.substring(0, pos);
+      }
+
+      if (glob.length() > text.length())
+         return false;
+
+      // handle the part up to the first *
+      for (int i = 0; i < glob.length(); i++)
+         if (glob.charAt(i) != '?'
+                 && !glob.substring(i, i + 1).equalsIgnoreCase(text.substring(i, i + 1)))
+            return false;
+
+      // recurse for the part after the first *, if any
+      if (rest == null) {
+         return glob.length() == text.length();
+      } else {
+         for (int i = glob.length(); i <= text.length(); i++) {
+            if (globmatches(text.substring(i), rest))
+                return true;
+         }
+         return false;
+      }
+   }
+
    @Override
    public List<ProviderConfigProperty> getConfigProperties() {
       return CONFIG_PROPERTIES;
@@ -81,7 +113,10 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
 
       String[] domains = mailDomainConfig.getConfig().getOrDefault("validDomains","exemple.org").split("##");
       for (String domain : domains) {
-         if (email.endsWith(domain)) {
+         if (email.endsWith("@" + domain)) {
+            emailDomainValid = true;
+            break;
+         } else if (globmatches(email, "*@" + domain)) {
             emailDomainValid = true;
             break;
          }


### PR DESCRIPTION
Hi there,

This changes the following things:

- add a globmatches function (limited to 200 chars because we're matching domains heh -> courtesy of https://stackoverflow.com/a/3687031
- allow to specify a glob-style pattern for domains (matches `*` and `?`)
- prevent a domain with same suffix from validating the mails: fooexemple.org would validate exemple.org before, now it's no longer the case.