### PR TITLE
Add the list of authorized mails in registration forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ Simply drop the jar in `$KEYCLOAK_HOME\standalone\deployments`, it will be autom
 - Configure this new execution (otherwise, keycloak will only accept "exemple.org" domains)
 - Change the registration binding to this new flow
 - Configure the realm to accept registration and verify email (this is important!)
+
+##  Display authorized mail domains in register forms
+
+This extension provides the list of authorized patterns in the `authorizedMailDomains` attribute of the registration page.
+
+This can be used like this : 
+
+```
+ <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="email" class="${properties.kcLabelClass!}">${msg("email")} (only ${authorizedMailDomains?join(", ")})</label>
+ </div>
+```

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
@@ -1,16 +1,19 @@
 package net.micedre.keycloak.registration;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.keycloak.authentication.FormAction;
+import org.keycloak.authentication.FormContext;
 import org.keycloak.authentication.ValidationContext;
 import org.keycloak.authentication.forms.RegistrationPage;
 import org.keycloak.authentication.forms.RegistrationProfile;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
+import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -55,6 +58,7 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
       CONFIG_PROPERTIES.add(property);
    }
 
+   
    private static final boolean globmatches(String text, String glob) {
       if (text.length() > 200) {
          return false;
@@ -134,6 +138,14 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
          context.success();
       }
 
+   }
+
+
+   @Override
+   public void buildPage(FormContext context, LoginFormsProvider form) {
+      List<String> authorizedMailDomains = Arrays.asList(
+         context.getAuthenticatorConfig().getConfig().getOrDefault("validDomains","exemple.org").split("##"));
+      form.setAttribute("authorizedMailDomains", authorizedMailDomains);
    }
 
 }


### PR DESCRIPTION
This work by adding the `authorizedMailDomains` attribute in the form before displaying it.