### PR TITLE
Fix for compatibility with KC 19¨+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <keycloak.version>9.0.3</keycloak.version>
+    <keycloak.version>19.0.0</keycloak.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
@@ -53,8 +53,8 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
       property = new ProviderConfigProperty();
       property.setName("validDomains");
       property.setLabel("Valid domain for emails");
-      property.setType(ProviderConfigProperty.MULTIVALUED_STRING_TYPE);
-      property.setHelpText("List mail domains authorized to register");
+      property.setType(ProviderConfigProperty.STRING_TYPE);
+      property.setHelpText("List mail domains authorized to register, separated by '##'");
       CONFIG_PROPERTIES.add(property);
    }
 
@@ -114,8 +114,8 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
          context.validationError(formData, errors);
          return;
       }
-
-      String[] domains = mailDomainConfig.getConfig().getOrDefault("validDomains","exemple.org").split("##");
+      
+      String[] domains = mailDomainConfig.getConfig().getOrDefault("validDomains", "example.com").split("##");
       for (String domain : domains) {
          if (email.endsWith("@" + domain) || email.equals(domain)) {
             emailDomainValid = true;
@@ -147,5 +147,6 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfile 
          context.getAuthenticatorConfig().getConfig().getOrDefault("validDomains","exemple.org").split("##"));
       form.setAttribute("authorizedMailDomains", authorizedMailDomains);
    }
+
 
 }


### PR DESCRIPTION
The ui for configuring valid domains changed. It is now just a simple textfield expecting a list of valid domains separated by '##'

closes #53 