### PR TITLE
feat: adding support for Keycloak 22

### DIFF
--- a/.github/workflows/deploy-maven.yml
+++ b/.github/workflows/deploy-maven.yml
@@ -8,9 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
+     - uses: actions/setup-java@v3
+       with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.micedre.keycloak</groupId>
   <artifactId>keycloak-mail-whitelisting</artifactId>
-  <version>1.7-SNAPSHOT</version>
+  <version>1.8-SNAPSHOT</version>
 
   <name>Keycloak mail whitelisting extension</name>
   <description>A keycloak extension to block non authorized domain to register</description>
@@ -30,9 +30,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <keycloak.version>19.0.0</keycloak.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <keycloak.version>22.0.0</keycloak.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationProfileDomainValidation.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationProfileDomainValidation.java
@@ -1,5 +1,6 @@
 package net.micedre.keycloak.registration;
 
+import org.jboss.logging.Logger;
 import org.keycloak.authentication.FormAction;
 import org.keycloak.authentication.ValidationContext;
 import org.keycloak.authentication.forms.RegistrationPage;
@@ -11,18 +12,18 @@ import org.keycloak.models.utils.FormMessage;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.validation.Validation;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class RegistrationProfileDomainValidation extends RegistrationProfile implements FormAction {
+   protected static final Logger logger = Logger.getLogger(RegistrationProfileDomainValidation.class);
 
-   protected static String domainListConfigName;
    protected static final String DEFAULT_DOMAIN_LIST = "example.org";
    protected static final String DOMAIN_LIST_SEPARATOR = "##";
 
    @Override
-    public boolean isConfigurable() {
+   public boolean isConfigurable() {
         return true;
    }
 
@@ -76,7 +77,8 @@ public abstract class RegistrationProfileDomainValidation extends RegistrationPr
          return;
       }
 
-      String[] domainList = mailDomainConfig.getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR);
+      String[] domainList = getDomainList(mailDomainConfig);
+
       boolean emailDomainValid = isEmailValid(email, domainList);
 
       if (!emailDomainValid) {
@@ -90,6 +92,8 @@ public abstract class RegistrationProfileDomainValidation extends RegistrationPr
          context.success();
       }
    }
+
+   public abstract String[] getDomainList(AuthenticatorConfigModel mailDomainConfig);
 
    public abstract boolean isEmailValid(String email, String[] domains);
 }

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithDomainBlock.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithDomainBlock.java
@@ -1,21 +1,23 @@
 package net.micedre.keycloak.registration;
 
+import org.keycloak.authentication.FormContext;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.models.AuthenticatorConfigModel;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.keycloak.authentication.FormContext;
-import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.provider.ProviderConfigProperty;
-
 public class RegistrationProfileWithDomainBlock extends RegistrationProfileDomainValidation {
 
    public static final String PROVIDER_ID = "registration-domain-block-action";
+
    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
 
-   static {
-      domainListConfigName = "invalidDomains";
+   public static String domainListConfigName = "invalidDomains";
 
+   static {
       ProviderConfigProperty property;
       property = new ProviderConfigProperty();
       property.setName(domainListConfigName);
@@ -26,7 +28,7 @@ public class RegistrationProfileWithDomainBlock extends RegistrationProfileDomai
    }
 
    @Override
-    public String getDisplayType() {
+   public String getDisplayType() {
         return "Profile Validation with domain block";
    }
 
@@ -50,6 +52,11 @@ public class RegistrationProfileWithDomainBlock extends RegistrationProfileDomai
       List<String> unauthorizedMailDomains = Arrays.asList(
          context.getAuthenticatorConfig().getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR));
       form.setAttribute("unauthorizedMailDomains", unauthorizedMailDomains);
+   }
+
+   @Override
+   public String[] getDomainList(AuthenticatorConfigModel mailDomainConfig) {
+      return mailDomainConfig.getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR);
    }
 
    @Override

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationProfileWithMailDomainCheck.java
@@ -3,6 +3,7 @@ package net.micedre.keycloak.registration;
 import org.keycloak.authentication.FormContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.models.AuthenticatorConfigModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,9 +15,9 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfileD
 
    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
 
-   static {
-      domainListConfigName = "validDomains";
+   public static String domainListConfigName = "validDomains";
 
+   static {
       ProviderConfigProperty property;
       property = new ProviderConfigProperty();
       property.setName(domainListConfigName);
@@ -51,6 +52,11 @@ public class RegistrationProfileWithMailDomainCheck extends RegistrationProfileD
       List<String> authorizedMailDomains = Arrays.asList(
          context.getAuthenticatorConfig().getConfig().getOrDefault(domainListConfigName,DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR));
       form.setAttribute("authorizedMailDomains", authorizedMailDomains);
+   }
+
+   @Override
+   public String[] getDomainList(AuthenticatorConfigModel mailDomainConfig) {
+      return mailDomainConfig.getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR);
    }
 
    @Override


### PR DESCRIPTION
**[ADDED]**
- Keycloak and Maven compiler versions have been updated in `pom.xml`;
- Importing `MultivaluedMap` from `jakarta.ws.rs.core`;

**[FIX]**
- The static property `domainListConfigName` is being configured directly in the `RegistrationProfileWithDomainBlock` and `RegistrationProfileWithMailDomainCheck` classes. This prevents this property from being overwritten.