### PR TITLE
Make necessary changes for Keycloak 23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <keycloak.version>22.0.0</keycloak.version>
+    <keycloak.version>23.0.3</keycloak.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationDomainValidation.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationDomainValidation.java
@@ -2,9 +2,10 @@ package net.micedre.keycloak.registration;
 
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.FormAction;
+import org.keycloak.authentication.FormContext;
 import org.keycloak.authentication.ValidationContext;
 import org.keycloak.authentication.forms.RegistrationPage;
-import org.keycloak.authentication.forms.RegistrationProfile;
+import org.keycloak.authentication.forms.RegistrationUserCreation;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.models.AuthenticatorConfigModel;
@@ -16,8 +17,8 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class RegistrationProfileDomainValidation extends RegistrationProfile implements FormAction {
-   protected static final Logger logger = Logger.getLogger(RegistrationProfileDomainValidation.class);
+public abstract class RegistrationUserCreationDomainValidation extends RegistrationUserCreation implements FormAction {
+   protected static final Logger logger = Logger.getLogger(RegistrationUserCreationDomainValidation.class);
 
    protected static final String DEFAULT_DOMAIN_LIST = "example.org";
    protected static final String DOMAIN_LIST_SEPARATOR = "##";
@@ -25,6 +26,10 @@ public abstract class RegistrationProfileDomainValidation extends RegistrationPr
    @Override
    public boolean isConfigurable() {
         return true;
+   }
+
+   @Override
+   public void success(FormContext context) {
    }
 
    protected static final boolean globmatches(String text, String glob) {

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithDomainBlock.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithDomainBlock.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class RegistrationProfileWithDomainBlock extends RegistrationProfileDomainValidation {
+public class RegistrationUserCreationWithDomainBlock extends RegistrationUserCreationDomainValidation {
 
    public static final String PROVIDER_ID = "registration-domain-block-action";
 

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithMailDomainCheck.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithMailDomainCheck.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class RegistrationProfileWithMailDomainCheck extends RegistrationProfileDomainValidation {
+public class RegistrationUserCreationWithMailDomainCheck extends RegistrationUserCreationDomainValidation {
 
    public static final String PROVIDER_ID = "registration-mail-check-action";
 

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
@@ -1,2 +1,2 @@
-net.micedre.keycloak.registration.RegistrationProfileWithMailDomainCheck
-net.micedre.keycloak.registration.RegistrationProfileWithDomainBlock
+net.micedre.keycloak.registration.RegistrationUserCreationWithMailDomainCheck
+net.micedre.keycloak.registration.RegistrationUserCreationWithDomainBlock


### PR DESCRIPTION
This PR switches from using `RegistrationProfile` to `RegistrationUserCreation` because [`RegistrationProfile` was removed in Keycloak 23](https://www.keycloak.org/docs/latest/upgrading/index.html#removed-registrationprofile-form-action) and renames all classes accordingly.
Also, it adds an override of the `success` function of `RegistrationUserCreation` because without it, [the instant login after registration would fail](https://keycloak.discourse.group/t/adjusting-registration-spi-for-keycloak-23/23836).
I tested the whitelist and blacklist functionality with my changes and Keycloak 23, it works fine.
Hope you can review these changes and include them in the plugin :)
closes #74 