### PR TITLE
Whitelist ORG domain users to register

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <keycloak.version>22.0.0</keycloak.version>
+    <keycloak.version>26.2.5</keycloak.version>
   </properties>
 
   <dependencies>
@@ -61,6 +61,7 @@
       <version>${keycloak.version}</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -74,7 +75,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -87,7 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.11.2</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -97,7 +98,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationDomainValidation.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationDomainValidation.java
@@ -25,7 +25,7 @@ public abstract class RegistrationUserCreationDomainValidation extends Registrat
 
    @Override
    public boolean isConfigurable() {
-        return true;
+      return true;
    }
 
    @Override
@@ -71,10 +71,9 @@ public abstract class RegistrationUserCreationDomainValidation extends Registrat
       List<FormMessage> errors = new ArrayList<>();
       String email = formData.getFirst(Validation.FIELD_EMAIL);
 
-      AuthenticatorConfigModel mailDomainConfig = context.getAuthenticatorConfig();
       String eventError = Errors.INVALID_REGISTRATION;
 
-      if(email == null){
+      if (email == null){
          context.getEvent().detail(Details.EMAIL, email);
          errors.add(new FormMessage(RegistrationPage.FIELD_EMAIL, Messages.INVALID_EMAIL));
          context.error(eventError);
@@ -82,7 +81,7 @@ public abstract class RegistrationUserCreationDomainValidation extends Registrat
          return;
       }
 
-      String[] domainList = getDomainList(mailDomainConfig);
+      List<String> domainList = getDomainList(context);
 
       boolean emailDomainValid = isEmailValid(email, domainList);
 
@@ -98,8 +97,12 @@ public abstract class RegistrationUserCreationDomainValidation extends Registrat
       }
    }
 
-   public abstract String[] getDomainList(AuthenticatorConfigModel mailDomainConfig);
+   public List<String> getDomainList(ValidationContext validationContext) {
+      return getDomainList(validationContext.getAuthenticatorConfig());
+   }
 
-   public abstract boolean isEmailValid(String email, String[] domains);
+   public abstract List<String> getDomainList(AuthenticatorConfigModel mailDomainConfig);
+
+   public abstract boolean isEmailValid(String email, List<String> domains);
 }
 

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithDomainBlock.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithDomainBlock.java
@@ -21,15 +21,15 @@ public class RegistrationUserCreationWithDomainBlock extends RegistrationUserCre
       ProviderConfigProperty property;
       property = new ProviderConfigProperty();
       property.setName(domainListConfigName);
-      property.setLabel("Invalid domain for emails");
+      property.setLabel("Blacklisted e-mail domains");
       property.setType(ProviderConfigProperty.TEXT_TYPE);
-      property.setHelpText("List mail domains not authorized to register, separated by '##' or new line");
+      property.setHelpText("List mail domains not authorized to register, separated by '##' or new line.");
       CONFIG_PROPERTIES.add(property);
    }
 
    @Override
    public String getDisplayType() {
-        return "Profile Validation with domain block";
+        return "Profile Validation with Blacklisted Domains";
    }
 
    @Override
@@ -50,17 +50,21 @@ public class RegistrationUserCreationWithDomainBlock extends RegistrationUserCre
    @Override
    public void buildPage(FormContext context, LoginFormsProvider form) {
       List<String> unauthorizedMailDomains = Arrays.asList(
-         context.getAuthenticatorConfig().getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR));
+         context.getAuthenticatorConfig().getConfig()
+         .getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST)
+         .split(DOMAIN_LIST_SEPARATOR));
       form.setAttribute("unauthorizedMailDomains", unauthorizedMailDomains);
    }
 
    @Override
-   public String[] getDomainList(AuthenticatorConfigModel mailDomainConfig) {
-      return mailDomainConfig.getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR);
+   public List<String> getDomainList(AuthenticatorConfigModel mailDomainConfig) {
+      return List.of(mailDomainConfig.getConfig()
+         .getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST)
+         .split(DOMAIN_LIST_SEPARATOR));
    }
 
    @Override
-   public boolean isEmailValid(String email, String[] domains) {
+   public boolean isEmailValid(String email, List<String> domains) {
       for (String domain : domains) {
          if (email.endsWith("@" + domain) || email.equals(domain) || globmatches(email, "*@" + domain)) {
             return false;

--- a/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithMailDomainCheck.java
+++ b/src/main/java/net/micedre/keycloak/registration/RegistrationUserCreationWithMailDomainCheck.java
@@ -1,13 +1,20 @@
 package net.micedre.keycloak.registration;
 
 import org.keycloak.authentication.FormContext;
+import org.keycloak.authentication.ValidationContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationDomainModel;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.organization.OrganizationProvider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RegistrationUserCreationWithMailDomainCheck extends RegistrationUserCreationDomainValidation {
 
@@ -15,21 +22,28 @@ public class RegistrationUserCreationWithMailDomainCheck extends RegistrationUse
 
    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
 
+   public static String orgDomainCheckConfigName = "allowOrgDomains";
    public static String domainListConfigName = "validDomains";
 
    static {
       ProviderConfigProperty property;
       property = new ProviderConfigProperty();
+      property.setName(orgDomainCheckConfigName);
+      property.setLabel("Allow Organizations Domains");
+      property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+      property.setHelpText("Allow domains of organizations of this realm.");
+      CONFIG_PROPERTIES.add(property);
+      property = new ProviderConfigProperty();
       property.setName(domainListConfigName);
-      property.setLabel("Valid domains for emails");
+      property.setLabel("Allowed Domains for E-mails");
       property.setType(ProviderConfigProperty.TEXT_TYPE);
-      property.setHelpText("List mail domains authorized to register, separated by '##' or new line");
+      property.setHelpText("List mail domains authorized to register, separated by '##' or new line.");
       CONFIG_PROPERTIES.add(property);
    }
 
    @Override
    public String getDisplayType() {
-        return "Profile Validation with email domain check";
+      return "Profile Validation with E-mail Domain Check";
    }
 
    @Override
@@ -50,17 +64,42 @@ public class RegistrationUserCreationWithMailDomainCheck extends RegistrationUse
    @Override
    public void buildPage(FormContext context, LoginFormsProvider form) {
       List<String> authorizedMailDomains = Arrays.asList(
-         context.getAuthenticatorConfig().getConfig().getOrDefault(domainListConfigName,DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR));
+         context.getAuthenticatorConfig().getConfig()
+         .getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST)
+         .split(DOMAIN_LIST_SEPARATOR));
       form.setAttribute("authorizedMailDomains", authorizedMailDomains);
    }
 
    @Override
-   public String[] getDomainList(AuthenticatorConfigModel mailDomainConfig) {
-      return mailDomainConfig.getConfig().getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST).split(DOMAIN_LIST_SEPARATOR);
+   public List<String> getDomainList(ValidationContext validationContext) {
+      AuthenticatorConfigModel mailDomainConfig = validationContext.getAuthenticatorConfig();
+      boolean orgDomains = Boolean.parseBoolean(mailDomainConfig.getConfig().get(orgDomainCheckConfigName));
+
+      List<String> domainNames = new LinkedList<>();
+
+      if (orgDomains && validationContext.getRealm().isOrganizationsEnabled()) {
+    	     KeycloakSession session = validationContext.getSession();
+         OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
+         provider.getAllStream()
+            .flatMap(OrganizationModel::getDomains)
+            .map(OrganizationDomainModel::getName)
+            .collect(Collectors.toCollection(() -> domainNames));
+      }
+
+      domainNames.addAll(getDomainList(mailDomainConfig));
+
+      return domainNames;
    }
 
    @Override
-   public boolean isEmailValid(String email, String[] domains) {
+   public List<String> getDomainList(AuthenticatorConfigModel mailDomainConfig) {
+      return List.of(mailDomainConfig.getConfig()
+         .getOrDefault(domainListConfigName, DEFAULT_DOMAIN_LIST)
+         .split(DOMAIN_LIST_SEPARATOR));
+   }
+
+   @Override
+   public boolean isEmailValid(String email, List<String> domains) {
       for (String domain : domains) {
          if (email.endsWith("@" + domain) || email.equals(domain) || globmatches(email, "*@" + domain)) {
             return true;


### PR DESCRIPTION
The purpose of this pull request is to extend the domain-based user whitelisting with ORG domains, so any user belonging to the domain associated with an organisation registered under the same Keycloak realm is automatically allowed to create new account i.e. is whitelisted. If there is no match against ORG domains, then the usual user-supplied list of e-mail domains is used as previously.

This new functionality is DISABLED by default upon plugin installation, but can be enabled at the same plugin configuration page by flagging the appropriate checkbox.